### PR TITLE
fix mismatch in documentation

### DIFF
--- a/R/pt_classes.R
+++ b/R/pt_classes.R
@@ -7,6 +7,7 @@
 #' @slot pstay numeric vector specifying parameter for non-perturbation
 #' @slot optim (integer) specifying optimization parameter for optimization function
 #' @slot mono (logical) vector specifying optimization parameter for monotony condition
+#' @slot pTableSize (integer) number of columns in pTable (abs-format)
 #' @slot label (character) label for output
 #' @name ptable_params-class
 #' @rdname ptable_params-class

--- a/man/pt_create_pParams.Rd
+++ b/man/pt_create_pParams.Rd
@@ -5,7 +5,7 @@
 \title{pt_create_pParams}
 \usage{
 pt_create_pParams(D, V, js = 0, pstay = NULL, optim = 1, mono = TRUE,
-  epsilon = 0.0000001, label = paste("D", D, "V", V * 100, sep = ""),
+  epsilon = 1e-07, label = paste("D", D, "V", V * 100, sep = ""),
   pTableSize = 70)
 }
 \arguments{

--- a/man/ptable_params-class.Rd
+++ b/man/ptable_params-class.Rd
@@ -26,6 +26,8 @@ An S4 class to represent perturbation parameters
 
 \item{\code{mono}}{(logical) vector specifying optimization parameter for monotony condition}
 
+\item{\code{pTableSize}}{(integer) number of columns in pTable (abs-format)}
+
 \item{\code{label}}{(character) label for output}
 }}
 


### PR DESCRIPTION
fix the docu mismatch after you changed the class-definition for the `table_params-class`